### PR TITLE
Fix last 7 questions issue

### DIFF
--- a/app/views/page/profile.js
+++ b/app/views/page/profile.js
@@ -453,7 +453,10 @@ class ProfilePage extends Backbone.View {
       datasetQuestion = _EXPLORER_DATASET.question_old
     }
     _.map(detailsData.questions, (val, key) => {
-      return val['question'] = datasetQuestion[key + 1]
+      const question = _.find(datasetQuestion, (question) => {
+        return String(question['number']) === val['number']
+      })
+      return val['question'] = question
     })
     if (target.id === 'print-plain') {
       $('.details').html(template_profile_details_future_print({data: detailsData}))


### PR DESCRIPTION
In my previous implementation I have overlooked the fact that questions that are not numerical do not follow the order suggested by the profile page - there are in fact much more questions that have numerical numbers and they were being showed instead of the ones "numbered by string".

This PR fixes #88 